### PR TITLE
Implement Flask API routes for AI activity

### DIFF
--- a/lms_frontend_flask/__init__.py
+++ b/lms_frontend_flask/__init__.py
@@ -1,0 +1,1 @@
+# Init file for lms_frontend_flask package

--- a/lms_frontend_flask/app.py
+++ b/lms_frontend_flask/app.py
@@ -1,4 +1,7 @@
-from flask import Flask, render_template, url_for, abort
+from flask import Flask, render_template, url_for, abort, request, jsonify
+import requests
+import uuid
+import json
 from .config import Config
 from .extensions import db
 from .models import Course, Module, Activity
@@ -14,7 +17,7 @@ app.config.from_object(Config)
 db.init_app(app)
 
 # Flask-Admin setup
-admin = Admin(app, name='LMS Content Admin', template_mode='bootstrap3')
+admin = Admin(app, name='LMS Content Admin')
 # Add administrative views here
 # Define custom ModelViews if needed for more control
 class SecureModelView(ModelView):
@@ -85,11 +88,67 @@ def show_activity(course_ext_id, module_ext_id, activity_ext_id):
 # Dummy API routes for url_for in templates (to be implemented later)
 @app.route('/api/activity/start', methods=['POST'])
 def start_ai_activity_api():
-    return {"status": "AI activity started (dummy response)", "session_id": "dummy_session_123"}
+    # In a real implementation, this might verify the user and activity,
+    # and maybe pre-create a session in a database.
+    # For now, we generate a session ID for the client to use.
+    session_id = str(uuid.uuid4())
+    return jsonify({"status": "AI activity started", "session_id": session_id})
 
 @app.route('/api/activity/interact', methods=['POST'])
 def interact_ai_activity_api():
-    return {"ai_messages": ["AI response (dummy)"], "xapi_statements": [], "is_activity_complete": False}
+    data = request.get_json()
+    if not data:
+        return jsonify({"error": "No JSON data provided"}), 400
+
+    session_id = data.get("session_id")
+    user_utterance = data.get("user_utterance")
+    user_id = data.get("user_id", "default_user") # Default if not provided
+    # Also possible: ai_activity_key, history, etc.
+    aita_persona_id = data.get("ai_activity_key")
+
+    if not user_utterance:
+        return jsonify({"error": "user_utterance is required"}), 400
+
+    # Payload for AITA Service
+    payload = {
+        "session_id": session_id,
+        "user_id": user_id,
+        "user_utterance": user_utterance,
+        "aita_persona_id": aita_persona_id if aita_persona_id else "default_phi3_base",
+        # We can pass conversation history if the frontend maintains it,
+        # or rely on the service to maintain it if session_id is persistent.
+        # But looking at InteractionRequest, it has conversation_history: List[Dict[str, str]] = []
+        # The frontend should probably send the history or the service should be stateful.
+        # The service implementation shows it takes history.
+        "conversation_history": data.get("conversation_history", [])
+    }
+
+    aita_url = app.config['AITA_SERVICE_URL'] + "/interact"
+
+    try:
+        response = requests.post(aita_url, json=payload, timeout=30)
+        response.raise_for_status()
+        result = response.json()
+
+        # Transform result to match what frontend expects if needed.
+        # Frontend currently expects: {"ai_messages": ["AI response (dummy)"], "xapi_statements": [], "is_activity_complete": False}
+        # Service returns: {"session_id": str, "aita_response": str, "debug_info": ...}
+
+        return jsonify({
+            "ai_messages": [result.get("aita_response")],
+            "session_id": result.get("session_id"),
+            # Pass through debug info or other fields if useful
+            "debug_info": result.get("debug_info"),
+            "is_activity_complete": False # Logic for completion could be added later
+        })
+
+    except requests.exceptions.ConnectionError:
+        print(f"ERROR: Could not connect to AITA service at {aita_url}")
+        # Fallback or error
+        return jsonify({"error": "AI Service unavailable"}), 503
+    except requests.exceptions.RequestException as e:
+        print(f"ERROR: AITA service request failed: {e}")
+        return jsonify({"error": f"AI Service error: {str(e)}"}), 500
 
 def create_tables():
     with app.app_context():

--- a/lms_frontend_flask/config.py
+++ b/lms_frontend_flask/config.py
@@ -17,6 +17,7 @@ class Config:
                               'postgresql://lms_user:lms_password@localhost:5432/lms_db_test_default'
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     FLASK_ADMIN_SWATCH = 'cerulean' # Optional: For theming Flask-Admin
+    AITA_SERVICE_URL = os.environ.get('AITA_SERVICE_URL') or 'http://localhost:8000'
 
     # For debugging:
     # print(f"DEBUG: FLASK_SECRET_KEY: {SECRET_KEY}")

--- a/lms_frontend_flask/requirements.txt
+++ b/lms_frontend_flask/requirements.txt
@@ -4,3 +4,4 @@ psycopg2-binary
 Flask-Admin
 python-dotenv
 gunicorn
+requests

--- a/lms_frontend_flask/static/js/main.js
+++ b/lms_frontend_flask/static/js/main.js
@@ -5,3 +5,133 @@
 // - Dynamically updating the DOM with course content, AI messages, etc.
 
 console.log("main.js loaded");
+
+document.addEventListener('DOMContentLoaded', function() {
+    const chatHistory = document.getElementById('chat-history');
+    const studentInput = document.getElementById('student-input');
+    const sendButton = document.getElementById('send-button');
+    const startUrl = document.getElementById('start-activity-url') ? document.getElementById('start-activity-url').value : null;
+    const interactUrl = document.getElementById('interact-activity-url') ? document.getElementById('interact-activity-url').value : null;
+    const userId = document.getElementById('current-user-id') ? document.getElementById('current-user-id').value : 'guest';
+    const activityKey = document.getElementById('current-activity-key') ? document.getElementById('current-activity-key').value : null;
+
+    let sessionId = null;
+    let conversationHistory = []; // To maintain history if needed on client side
+
+    // Helper to append messages
+    function appendMessage(sender, text, isError=false) {
+        if (!chatHistory) return;
+        const msgDiv = document.createElement('div');
+        msgDiv.style.marginBottom = '10px';
+        msgDiv.style.padding = '8px';
+        msgDiv.style.borderRadius = '5px';
+
+        if (sender === 'User') {
+            msgDiv.style.backgroundColor = '#e1f5fe';
+            msgDiv.style.textAlign = 'right';
+            const strong = document.createElement('strong');
+            strong.textContent = 'You: ';
+            msgDiv.appendChild(strong);
+            msgDiv.appendChild(document.createTextNode(text));
+        } else {
+            msgDiv.style.backgroundColor = isError ? '#ffebee' : '#f1f8e9';
+            msgDiv.style.textAlign = 'left';
+            const strong = document.createElement('strong');
+            strong.textContent = sender + ': ';
+            msgDiv.appendChild(strong);
+            msgDiv.appendChild(document.createTextNode(text));
+        }
+        chatHistory.appendChild(msgDiv);
+        chatHistory.scrollTop = chatHistory.scrollHeight;
+    }
+
+    // Start Activity
+    if (startUrl && activityKey) {
+        fetch(startUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                user_id: userId,
+                activity_key: activityKey
+            })
+        })
+        .then(response => response.json())
+        .then(data => {
+            console.log("Activity Started:", data);
+            if (data.session_id) {
+                sessionId = data.session_id;
+            }
+        })
+        .catch(error => {
+            console.error("Error starting activity:", error);
+            appendMessage("System", "Failed to start AI session.", true);
+        });
+    }
+
+    // Interact function
+    function sendMessage() {
+        const text = studentInput.value.trim();
+        if (!text) return;
+
+        appendMessage("User", text);
+        studentInput.value = '';
+        studentInput.disabled = true;
+        sendButton.disabled = true;
+
+        if (!interactUrl || !sessionId) {
+            appendMessage("System", "Session not initialized or API unavailable.", true);
+            studentInput.disabled = false;
+            sendButton.disabled = false;
+            return;
+        }
+
+        const payload = {
+            session_id: sessionId,
+            user_id: userId,
+            user_utterance: text,
+            ai_activity_key: activityKey,
+            conversation_history: conversationHistory
+        };
+
+        fetch(interactUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+        })
+        .then(response => response.json())
+        .then(data => {
+            if (data.error) {
+                appendMessage("System", "Error: " + data.error, true);
+            } else if (data.ai_messages && data.ai_messages.length > 0) {
+                data.ai_messages.forEach(msg => {
+                    appendMessage("AI Assistant", msg);
+                    conversationHistory.push({role: "user", content: text});
+                    conversationHistory.push({role: "assistant", content: msg});
+                });
+            } else {
+                 appendMessage("System", "No response from AI.", true);
+            }
+        })
+        .catch(error => {
+            console.error("Error interacting:", error);
+            appendMessage("System", "Error communicating with server.", true);
+        })
+        .finally(() => {
+            studentInput.disabled = false;
+            sendButton.disabled = false;
+            studentInput.focus();
+        });
+    }
+
+    if (sendButton) {
+        sendButton.addEventListener('click', sendMessage);
+    }
+
+    if (studentInput) {
+        studentInput.addEventListener('keypress', function(e) {
+            if (e.key === 'Enter') {
+                sendMessage();
+            }
+        });
+    }
+});

--- a/lms_frontend_flask/test_api_routes.py
+++ b/lms_frontend_flask/test_api_routes.py
@@ -1,0 +1,87 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+import os
+import json
+
+# Set environment variable for DB before importing app to ensure Config picks it up
+# or at least before db connects.
+os.environ['FLASK_DATABASE_URL'] = 'sqlite:///:memory:'
+
+# Assuming we run this from the repo root as: python3 -m lms_frontend_flask.test_api_routes
+from lms_frontend_flask.app import app, db
+
+class TestAPIRoutes(unittest.TestCase):
+    def setUp(self):
+        app.config['TESTING'] = True
+        app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+        self.client = app.test_client()
+        with app.app_context():
+            db.create_all()
+
+    def tearDown(self):
+        with app.app_context():
+            db.session.remove()
+            db.drop_all()
+
+    def test_start_ai_activity_api(self):
+        response = self.client.post('/api/activity/start', json={
+            "user_id": "test_user",
+            "activity_key": "test_activity"
+        })
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+        self.assertIn("session_id", data)
+        self.assertEqual(data["status"], "AI activity started")
+
+    @patch('lms_frontend_flask.app.requests.post')
+    def test_interact_ai_activity_api_success(self, mock_post):
+        # Mock response from AITA service
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "session_id": "session_123",
+            "aita_response": "Hello, student!",
+            "debug_info": {}
+        }
+        mock_post.return_value = mock_response
+
+        payload = {
+            "session_id": "session_123",
+            "user_id": "test_user",
+            "user_utterance": "Hello AI",
+            "ai_activity_key": "test_activity"
+        }
+
+        response = self.client.post('/api/activity/interact', json=payload)
+        self.assertEqual(response.status_code, 200)
+        data = response.get_json()
+        self.assertIn("ai_messages", data)
+        self.assertEqual(data["ai_messages"][0], "Hello, student!")
+        self.assertEqual(data["session_id"], "session_123")
+
+    @patch('lms_frontend_flask.app.requests.post')
+    def test_interact_ai_activity_api_failure(self, mock_post):
+        # Mock connection error
+        import requests
+        mock_post.side_effect = requests.exceptions.RequestException("Connection refused")
+
+        payload = {
+            "session_id": "session_123",
+            "user_id": "test_user",
+            "user_utterance": "Hello AI",
+            "ai_activity_key": "test_activity"
+        }
+
+        response = self.client.post('/api/activity/interact', json=payload)
+        # Should return 500
+        self.assertEqual(response.status_code, 500)
+        data = response.get_json()
+        self.assertIn("error", data)
+
+    def test_interact_ai_activity_api_missing_data(self):
+        response = self.client.post('/api/activity/interact', json={})
+        self.assertEqual(response.status_code, 400)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implemented `start_ai_activity_api` and `interact_ai_activity_api` in `lms_frontend_flask/app.py`.
- Added `requests` to `requirements.txt`.
- Updated `config.py` to include `AITA_SERVICE_URL`.
- Implemented `start_ai_activity_api` to generate a session ID.
- Implemented `interact_ai_activity_api` to proxy requests to `aita_interaction_service`.
- Updated `lms_frontend_flask/static/js/main.js` to implement the chat interface using these APIs, ensuring XSS safety.
- Added `lms_frontend_flask/test_api_routes.py` for unit testing.
- Added `lms_frontend_flask/__init__.py` to support module execution.
- Fixed `Flask-Admin` deprecated configuration.


---
*PR created automatically by Jules for task [10399512680382954697](https://jules.google.com/task/10399512680382954697) started by @ashleycribb*